### PR TITLE
Heat pump info opens & instructions moved to separate component

### DIFF
--- a/frontend/src/components/Demo.jsx
+++ b/frontend/src/components/Demo.jsx
@@ -1,4 +1,4 @@
-import { Box, Button, Grid, Popover, Typography } from '@mui/material';
+import { Box, Button, Grid, Popover } from '@mui/material';
 import { useNavigate } from "react-router-dom";
 import { useState } from "react"
 import EnergyComponent from './EnergyComponent';
@@ -30,16 +30,6 @@ const Demo = () => {
   };
 
   const [openInstructions, setOpenInstructions] = useState(false);
-
-  const [componentOpen, setComponentOpen] = useState(false);
-
-  const handleOpen = () => {
-    setComponentOpen(true);
-  }
-
-  const handleClose = () => {
-    setComponentOpen(false);
-  }
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -111,6 +101,7 @@ const Demo = () => {
           />
           <div>
             <img
+              id="2" // id of heat pump in test data
               src={airHeatPumpImage}
               alt='heatPump'
               className='air-heat-pump'
@@ -121,7 +112,19 @@ const Demo = () => {
                 width: '2%',
                 height: '8%',
               }}
-              onClick={handleOpen}
+              onClick={() =>
+                navigate(`/component/2`, 
+                  {
+                    state: {component: {
+                      id: "2", 
+                      name: "Heat pump",
+                      type: "consumer",
+                      description: "Heat pump is used to adjust the temperature inside the house",
+                      demoTime: {demoTime}
+                    }},
+                    replace: true
+                  }
+                )}
               onMouseEnter={handleHoverOn}
               onMouseLeave={handleHoverAway}
               />
@@ -139,27 +142,16 @@ const Demo = () => {
                 }}
                 onClose={handleHoverAway}
                 disableRestoreFocus
-              >
-                <Typography 
-                  sx={{margin: 1 }}>
-                  <strong>Heat pump</strong><br/>
-                  Click the component for more info
-                </Typography>
-              </Popover>
-              {componentOpen &&
-                <Box style={{position: 'absolute', zIndex: 1}}>
-                  <EnergyComponent 
+              >                
+                <EnergyComponent 
                   id="2"
                   name="Heat pump"
                   type="consumer"
                   description="Heat pump is used to adjust the temperature inside the house"
                   demoTime={demoTime}
-                  handleClose={handleClose}
                   />
-                </Box>
-              }
-              
-                
+              </Popover>
+      
           <img
             src={freezerImage}
             alt='freezer'

--- a/frontend/src/components/Demo.jsx
+++ b/frontend/src/components/Demo.jsx
@@ -1,4 +1,4 @@
-import { Box, Button, Grid } from '@mui/material';
+import { Box, Button, Grid, Popover, Typography } from '@mui/material';
 import { useNavigate } from "react-router-dom";
 import { useState } from "react"
 import EnergyComponent from './EnergyComponent';
@@ -40,6 +40,18 @@ const Demo = () => {
   const handleClose = () => {
     setComponentOpen(false);
   }
+
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleHoverOn = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleHoverAway = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
 
   return (
     //Created container grid
@@ -109,22 +121,45 @@ const Demo = () => {
                 width: '2%',
                 height: '8%',
               }}
-              onMouseEnter={handleOpen}
+              onClick={handleOpen}
+              onMouseEnter={handleHoverOn}
+              onMouseLeave={handleHoverAway}
               />
+              <Popover
+                sx={{pointerEvents: 'none'}}
+                open={open}
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                }}
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'left',
+                }}
+                onClose={handleHoverAway}
+                disableRestoreFocus
+              >
+                <Typography 
+                  sx={{margin: 1 }}>
+                  <strong>Heat pump</strong><br/>
+                  Click the component for more info
+                </Typography>
+              </Popover>
               {componentOpen &&
-              <Box style={{position: 'absolute', zIndex: 1}}>
-                <EnergyComponent 
-                id="2"
-                name="Heat pump"
-                type="consumer"
-                description="Heat pump is used to adjust the temperature inside the house"
-                demoTime={demoTime}
-                handleClose={handleClose}
-              />
-              </Box>
+                <Box style={{position: 'absolute', zIndex: 1}}>
+                  <EnergyComponent 
+                  id="2"
+                  name="Heat pump"
+                  type="consumer"
+                  description="Heat pump is used to adjust the temperature inside the house"
+                  demoTime={demoTime}
+                  handleClose={handleClose}
+                  />
+                </Box>
               }
+              
                 
-          
           <img
             src={freezerImage}
             alt='freezer'

--- a/frontend/src/components/Demo.jsx
+++ b/frontend/src/components/Demo.jsx
@@ -1,16 +1,7 @@
-import { 
-  Box, 
-  Button, 
-  Grid, 
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle, 
-} from '@mui/material';
+import { Box, Button, Grid } from '@mui/material';
 import { useNavigate } from "react-router-dom";
 import { useState } from "react"
-//import EnergyComponent from './EnergyComponent';
+import EnergyComponent from './EnergyComponent';
 import DemoClock from './DemoClock';
 import RealtimeClock from './RealtimeClock';
 import ElectricityPrice from './ElectricityPrice'
@@ -27,6 +18,7 @@ import washingMachineImage from "./../assets/washing_machine.png";
 import solarPanelImage from "./../assets/solar_panel.png";
 import carImage from "./../assets/car.png";
 import electricBoardImage from "./../assets/electric_board.png";
+import Instructions from './Instructions';
 
 const Demo = () => {
   const navigate = useNavigate();
@@ -39,48 +31,14 @@ const Demo = () => {
 
   const [openInstructions, setOpenInstructions] = useState(false);
 
-  const handleCloseInstructions = () => {
-    setOpenInstructions(false);
+  const [componentOpen, setComponentOpen] = useState(false);
+
+  const handleOpen = () => {
+    setComponentOpen(true);
   }
 
-  const instructions = () => {
-    return (
-      <Dialog open={openInstructions} maxWidth={'sm'} fullWidth={true}>
-        
-          <DialogTitle sx={{display: 'flex', justifyContent: 'left', marginX: 2, marginTop: 2}}
-            >{"Liquid AI Demo"}
-          </DialogTitle>
-          <DialogContentText sx={{display: 'flex', justifyContent: 'center', marginX: 5}}>
-            The purpose of this demo is to show how energy consumption can be optimized in a
-            single-family house.
-          </DialogContentText>
-          <DialogTitle sx={{display: 'flex', justifyContent: 'left', marginX: 2, marginTop: 2}}
-            >{"Instructions for use"}
-          </DialogTitle>
-          <DialogContentText sx={{display: 'flex', justifyContent: 'left', marginX: 5}}>
-            You can select what components of the house are included in the demo from the Components
-            dropdown menu. You can inspect individual components by hovering over the component and 
-            clicking on it.<br/>
-            The demo shows the consumption and production of energy for each component and the price
-            of consumed energy by hour. The time range and speed of demo time can be changed from 
-            the dropdown menus.
-          </DialogContentText>
-          <DialogTitle sx={{display: 'flex', justifyContent: 'left', marginX: 2, marginTop: 2}}
-            >{"Source of the data"}
-          </DialogTitle>
-          <DialogContentText sx={{display: 'flex', justifyContent: 'left', marginX: 5}}>
-            Consumption and production data is currently made-up test data for demonstrating purposes.<br/>
-            The price data is fetched from Pörssisähkö API:
-          </DialogContentText>
-          <DialogContent sx={{display: 'flex', justifyContent: 'left', marginX: 2}}>
-            <a href="https://porssisahko.net">Link to the price API (the site is in Finnish)</a>
-          </DialogContent>
-          <DialogActions sx={{display: 'flex', justifyContent: 'center', margin: 2}}>
-            <Button variant='contained' onClick={handleCloseInstructions}>Back to demo</Button>
-          </DialogActions>
-
-      </Dialog>
-    );
+  const handleClose = () => {
+    setComponentOpen(false);
   }
 
   return (
@@ -140,18 +98,33 @@ const Demo = () => {
             }}
           />
           <div>
-          <img
-            src={airHeatPumpImage}
-            alt='heatPump'
-            className='air-heat-pump'
-            style={{
-              position: 'absolute',
-              top: '34%',
-              left: '38%',
-              width: '2%',
-              height: '8%',
-            }}
-          />
+            <img
+              src={airHeatPumpImage}
+              alt='heatPump'
+              className='air-heat-pump'
+              style={{
+                position: 'absolute',
+                top: '34%',
+                left: '38%',
+                width: '2%',
+                height: '8%',
+              }}
+              onMouseEnter={handleOpen}
+              />
+              {componentOpen &&
+              <Box style={{position: 'absolute', zIndex: 1}}>
+                <EnergyComponent 
+                id="2"
+                name="Heat pump"
+                type="consumer"
+                description="Heat pump is used to adjust the temperature inside the house"
+                demoTime={demoTime}
+                handleClose={handleClose}
+              />
+              </Box>
+              }
+                
+          
           <img
             src={freezerImage}
             alt='freezer'
@@ -392,18 +365,17 @@ const Demo = () => {
             <Button 
               variant="contained"
               onClick={() => navigate("/")}>
-            Back
+              Back
             </Button>
             </Grid>
             <Grid item xs={1} style={{minWidth: 200, margin: 5}}>
             <Button 
               variant="contained"
               onClick={() => setOpenInstructions(true)}>
-            More information
+              More information
             </Button>
             </Grid>
-            {instructions()}
-
+            <Instructions openInstructions={openInstructions} setOpenInstructions={setOpenInstructions}/>
           </Grid>
           
         </Grid>

--- a/frontend/src/components/EnergyComponent.jsx
+++ b/frontend/src/components/EnergyComponent.jsx
@@ -1,11 +1,8 @@
-import { Card, CardContent, CardActions, Typography } from '@mui/material';
-import { Button } from '@mui/material'; 
-import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, Typography } from '@mui/material';
 import energyComponents from "../../../test_data/energyComponents.json";
 
 const EnergyComponent = (props) => {
-  const { id, name, type, description, demoTime, handleClose } = props;
-  const navigate = useNavigate();
+  const { id, name, type, description, demoTime } = props;
   const component = {
     id: id,
     name: name,
@@ -40,14 +37,15 @@ const EnergyComponent = (props) => {
       maxWidth: '500px',
       minWidth: '250px',
       minHeight: '20%',
-      padding: '2vh',
-      margin: '1vh'}}>
-      <Typography variant='body1' margin='1vh'>{name}</Typography>
-      <CardContent>
+      padding: '0.5vh'
+      }}>
+      <CardContent sx={{margin: 0}}>
         {type === "consumer" &&
         <>
-          <Typography variant='body2'>
-            Consumer<br/>
+          <Typography variant='body2' sx={{marginBottom: 1}}>
+            <strong>{name}</strong> (Energy consumer)<br/>
+          </Typography>  
+          <Typography variant='body2' sx={{marginBottom: 1}}>
             Energy consumed between {demoHour}:00-{parseInt(demoHour)+1}:00<br/>
             {consumptionData.filter(h => h.startHour === demoHour).map(h => h.value)[0]} kwh <br/>
             Total consumption during the demo {totalConsumption} kwh
@@ -55,35 +53,19 @@ const EnergyComponent = (props) => {
         </> } 
         {type === "producer" &&
         <>
-          <Typography variant='body2'>
-            Producer<br/>
+          <Typography variant='body2' sx={{marginBottom: 1}}>
+            <strong>{name}</strong> (Energy producer)<br/>
+          </Typography>  
+          <Typography variant='body2' sx={{marginBottom: 1}}>
             Energy produced between {demoHour}:00-{parseInt(demoHour)+1}:00<br/>
             {productionData.filter(h => h.startHour === demoHour).map(h => h.value)[0]} kwh <br/>
             Total production during the demo {totalProduction} kwh
           </Typography>
         </> }
+        <Typography variant='body2'>
+          Click the component for more info
+        </Typography>
       </CardContent>
-      <CardActions sx={{display: 'flex', justifyContent: 'left'}}>
-        <Button 
-          variant='contained'
-          size='small'
-          sx={{marginX: 2}}
-          onClick={() => navigate(`/component/${id}`, 
-            {
-              state: {component: component},
-              replace: true
-            }
-          )}>
-          Show more
-        </Button>
-        <Button 
-          variant='contained'
-          size='small'
-          sx={{marginX: 2}}
-          onClick={handleClose}>
-          Close
-        </Button>
-      </CardActions>
     </Card>
   )
 }

--- a/frontend/src/components/EnergyComponent.jsx
+++ b/frontend/src/components/EnergyComponent.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import energyComponents from "../../../test_data/energyComponents.json";
 
 const EnergyComponent = (props) => {
-  const { id, name, type, description, demoTime } = props;
+  const { id, name, type, description, demoTime, handleClose } = props;
   const navigate = useNavigate();
   const component = {
     id: id,
@@ -63,17 +63,25 @@ const EnergyComponent = (props) => {
           </Typography>
         </> }
       </CardContent>
-      <CardActions>
-
+      <CardActions sx={{display: 'flex', justifyContent: 'left'}}>
         <Button 
+          variant='contained'
           size='small'
+          sx={{marginX: 2}}
           onClick={() => navigate(`/component/${id}`, 
-              {
-                state: {component: component},
-                replace: true
-              }
-            )}>
-            Show more
+            {
+              state: {component: component},
+              replace: true
+            }
+          )}>
+          Show more
+        </Button>
+        <Button 
+          variant='contained'
+          size='small'
+          sx={{marginX: 2}}
+          onClick={handleClose}>
+          Close
         </Button>
       </CardActions>
     </Card>

--- a/frontend/src/components/Instructions.jsx
+++ b/frontend/src/components/Instructions.jsx
@@ -1,0 +1,58 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContentText,
+  DialogContent,
+  DialogActions,
+  Button
+
+} from '@mui/material';
+//import { useState } from 'react';
+
+const Instructions = ({openInstructions, setOpenInstructions}) => {
+
+  const handleCloseInstructions = () => {
+    setOpenInstructions(false);
+  }
+
+  return (
+    {openInstructions} && 
+      <Dialog open={openInstructions} maxWidth={'sm'} fullWidth={true}>
+      
+        <DialogTitle sx={{display: 'flex', justifyContent: 'left', marginX: 2, marginTop: 2}}
+          >{"Liquid AI Demo"}
+        </DialogTitle>
+        <DialogContentText sx={{display: 'flex', justifyContent: 'center', marginX: 5}}>
+          The purpose of this demo is to show how energy consumption can be optimized in a
+          single-family house.
+        </DialogContentText>
+        <DialogTitle sx={{display: 'flex', justifyContent: 'left', marginX: 2, marginTop: 2}}
+          >{"Instructions for use"}
+        </DialogTitle>
+        <DialogContentText sx={{display: 'flex', justifyContent: 'left', marginX: 5}}>
+          You can select what components of the house are included in the demo from the Components
+          dropdown menu. You can inspect individual components by hovering over the component and 
+          clicking on it.<br/>
+          The demo shows the consumption and production of energy for each component and the price
+          of consumed energy by hour. The time range and speed of demo time can be changed from 
+          the dropdown menus.
+        </DialogContentText>
+        <DialogTitle sx={{display: 'flex', justifyContent: 'left', marginX: 2, marginTop: 2}}
+          >{"Source of the data"}
+        </DialogTitle>
+        <DialogContentText sx={{display: 'flex', justifyContent: 'left', marginX: 5}}>
+          Consumption and production data is currently made-up test data for demonstrating purposes.<br/>
+          The price data is fetched from Pörssisähkö API:
+        </DialogContentText>
+        <DialogContent sx={{display: 'flex', justifyContent: 'left', marginX: 2}}>
+          <a href="https://porssisahko.net">Link to the price API (the site is in Finnish)</a>
+        </DialogContent>
+        <DialogActions sx={{display: 'flex', justifyContent: 'center', margin: 2}}>
+          <Button variant='contained' onClick={handleCloseInstructions}>Back to demo</Button>
+        </DialogActions>
+
+    </Dialog>
+  );
+}
+
+export default Instructions;

--- a/frontend/src/tests/EnergyComponent.test.js
+++ b/frontend/src/tests/EnergyComponent.test.js
@@ -1,16 +1,14 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import EnergyComponent from '../components/EnergyComponent'
-import EnergyComponentPage from '../components/EnergyComponentPage'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 
 const now = new Date()
 
 const eComponent = {
-  id: 1,
+  id: '1',
   name: 'Test name',
-  type: 'Test type',
+  type: 'consumer',
   description: 'Test description',
   demoTime: now
 }
@@ -23,27 +21,9 @@ test("renders content correctly", () => {
     </MemoryRouter>
   )
   
-  expect(screen.getByText('Test name')).toBeInTheDocument()
-  // expect(screen.getByText('Energy Test type')).toBeInTheDocument()
-  expect(screen.getByText('Show more')).toBeInTheDocument()
-  expect(screen.queryByText('Test description')).not.toBeInTheDocument()
-})
-
-test('"Show more" button navigates to component page', async () => {
-
-  const componentPagePath = `/component/${eComponent.id}`
-  
-  render(
-    <MemoryRouter initialEntries={['/demo']}>
-      <Routes>
-        <Route path="/demo" element={<EnergyComponent {...eComponent} />} />
-        <Route path={componentPagePath} element={<EnergyComponentPage />} />
-      </Routes>
-    </MemoryRouter>
-  )
-
-  const showMoreButtonElement = screen.getByText('Show more')
-  await userEvent.click(showMoreButtonElement)
-  expect(screen.getByText(eComponent.description)).toBeInTheDocument()
+  expect(screen.getByText(`${eComponent.name}`)).toBeInTheDocument()
+  expect(screen.getByText(`(Energy ${eComponent.type})`)).toBeInTheDocument()
+  expect(screen.getByText('Click the component for more info')).toBeInTheDocument()
+  expect(screen.queryByText(`${eComponent.description}`)).not.toBeInTheDocument()
 })
 

--- a/frontend/src/tests/EnergyComponentPage.test.js
+++ b/frontend/src/tests/EnergyComponentPage.test.js
@@ -10,7 +10,7 @@ import MockAdapter from 'axios-mock-adapter'
 const axiosMock = new MockAdapter(axios)
 
 const eComponent = {
-  id: 1,
+  id: '1',
   name: 'Test name',
   type: 'Test type',
   description: 'Test description'


### PR DESCRIPTION
Viemällä hiiri ilmalämpöpumpun päälle aukeaa komponentin tietoruutu, josta klikkaamalla pääsee komponentin sivulle. Muille komponenteille ei vielä lisätty tätä ominaisuutta, pitää ehkä miettiä onko tämä järkevä tapa vai pitäisikö toteuttaa jollain muulla tavalla (esim. olisi luultavasti järkevää jos ruutu sulkeutuisi itsestään kun vie hiiren pois sen päältä, mutta en saanut tätä toimimaan ihan halutulla tavalla)

Siirretty myös ohjesivu erilliseksi komponentiksi pois demokomponentista.