### PR TITLE
small changes to democlock

### DIFF
--- a/frontend/cypress/e2e/energy_optimizer.cy.js
+++ b/frontend/cypress/e2e/energy_optimizer.cy.js
@@ -39,6 +39,8 @@ describe('Energy Optimizer app', () => {
     })
     
     it('user can pause and continue demo', () => {
+      cy.contains('Start').click()
+      cy.wait(1000)
       cy.contains('Pause').click()
       cy.get('#pause').should('have.text', 'Continue')
       cy.get('#demotimebox').invoke('text').then((time) => {
@@ -51,6 +53,7 @@ describe('Energy Optimizer app', () => {
     })
     
     it('user can restart demo', () => {
+      cy.contains('Start').click()
       cy.wait(1000)
       cy.contains('Pause').click()
       cy.get('#demotimebox').invoke('text').then((time) => {

--- a/frontend/src/components/DemoClock.jsx
+++ b/frontend/src/components/DemoClock.jsx
@@ -47,7 +47,7 @@ function DemoClock({ demoTime, demoPassedHours, onDemoTimeChange }) {
   const [demoPassedMinutes, setDemoPassedMinutes] = useState(0);
 
   const [isPaused, setIsPaused] = useState(
-    window.sessionStorage.getItem("isDemoPaused") === "true" || false
+    window.sessionStorage.getItem("isDemoPaused") === "true" || true
   );
 
   // Default speed 1 hour/sec
@@ -149,18 +149,19 @@ function DemoClock({ demoTime, demoPassedHours, onDemoTimeChange }) {
       newDemoTime.setMinutes(0, 0);
       setDemoPassedMinutes(0);
       onDemoTimeChange(newDemoTime, 0);
-      setIsPaused(false);
-      window.sessionStorage.setItem("isDemoPaused", false);
+      setIsPaused(true);
+      window.sessionStorage.setItem("isDemoPaused", true);
     } else if (selectedValue === "last") {
       const newDemoTime = new Date();
       newDemoTime.setDate(now.getDate() - 1);
       newDemoTime.setMinutes(0, 0);
       setDemoPassedMinutes(0);
       onDemoTimeChange(newDemoTime, 0);
-      setIsPaused(false);
-      window.sessionStorage.setItem("isDemoPaused", false);
+      setIsPaused(true);
+      window.sessionStorage.setItem("isDemoPaused", true);
     }
   };
+
 
   // Select speed menu, demo time, pause button and real time
   return (
@@ -226,10 +227,10 @@ function DemoClock({ demoTime, demoPassedHours, onDemoTimeChange }) {
             onClick={() => handleResetClick(start)}
             id="restart"
           >
-            Restart
+            {demoPassedHours === 0 && isPaused ? "Start" : "Restart"}
           </Button>
         </ThemeProvider>
-        {demoPassedHours < 24 ? (
+        {demoPassedHours < 24 && demoPassedHours > 0 || (demoPassedHours === 0 && demoPassedMinutes > 0) ? (
           <ThemeProvider theme={theme}>
             <Button
               variant="contained"

--- a/frontend/src/components/DemoClock.jsx
+++ b/frontend/src/components/DemoClock.jsx
@@ -227,7 +227,7 @@ function DemoClock({ demoTime, demoPassedHours, onDemoTimeChange }) {
             onClick={() => handleResetClick(start)}
             id="restart"
           >
-            {demoPassedHours === 0 && isPaused ? "Start" : "Restart"}
+            {demoPassedHours === 0 && demoPassedMinutes === 0 && isPaused ? "Start" : "Restart"}
           </Button>
         </ThemeProvider>
         {demoPassedHours < 24 && demoPassedHours > 0 || (demoPassedHours === 0 && demoPassedMinutes > 0) ? (

--- a/frontend/src/tests/DemoClock.test.js
+++ b/frontend/src/tests/DemoClock.test.js
@@ -13,13 +13,14 @@ test("renders content", () => {
   expect(screen.getByText(/Speed:/)).toBeInTheDocument()
   expect(screen.getByText(/Time range:/)).toBeInTheDocument()
   expect(screen.getByText(/Demo time:/)).toBeInTheDocument()
-  expect(screen.getByText('Pause')).toBeInTheDocument()
-  expect(screen.getByText('Restart')).toBeInTheDocument()
+  expect(screen.getByText('Start')).toBeInTheDocument()
 })
 
-test("demo time runs correctly", () => {
+test("demo time runs correctly", async () => {
   jest.useFakeTimers()
   render(<DemoClock demoTime={now.toISOString()} demoPassedHours={0} onDemoTimeChange={jest.fn()}/>)
+  const startButtonElement = screen.getByText('Start')
+  await user.click(startButtonElement)
   act(() => {
     jest.advanceTimersByTime(1000)
   })
@@ -32,8 +33,13 @@ test("demo time runs correctly", () => {
 test("pause button pauses demo time", async () => {
   jest.useFakeTimers()
   render(<DemoClock demoTime={now.toISOString()} demoPassedHours={0} onDemoTimeChange={jest.fn()}/>)
-  const pauseButtonElement = screen.getByText('Pause')
+  const startButtonElement = screen.getByText('Start')
+  await user.click(startButtonElement)
+  act(() => {
+    jest.advanceTimersByTime(1000)
+  })
   
+  const pauseButtonElement = screen.getByText('Pause')
   await user.click(pauseButtonElement)
   act(() => {
     jest.advanceTimersByTime(2000)
@@ -41,13 +47,15 @@ test("pause button pauses demo time", async () => {
   
   const pausedDemoTime = screen.getByText(/Demo time:/).parentElement
   const currentHrs = String(now.getHours()).padStart(2, '0')
-  expect(pausedDemoTime).toHaveTextContent(`Demo time: ${currentHrs}:00`)
+  expect(pausedDemoTime).toHaveTextContent(`Demo time: ${currentHrs}:10`)
   jest.useRealTimers()
 })
 
 test("restart button restarts demo time", async () => {
   jest.useFakeTimers()
   render(<DemoClock demoTime={now.toISOString()} demoPassedHours={0} onDemoTimeChange={jest.fn()}/>)
+  const startButtonElement = screen.getByText('Start')
+  await user.click(startButtonElement)
   const restartButtonElement = screen.getByText('Restart')
   
   act(() => {


### PR DESCRIPTION
Demokello ei käynnisty automaattisesti demon käynnistyessä. Muutettu restart-napin tekstiksi "Start" ennen ensimmäistä käynnistystä ja myös kun vaihtaa näytettävää aikaväliä. Myös continue/pause-nappi piilotetaan silloin kun demoaika on kulunut kokonaan.